### PR TITLE
Better randomization

### DIFF
--- a/firmware/WS2812_FX_1.02/CONTROL.ino
+++ b/firmware/WS2812_FX_1.02/CONTROL.ino
@@ -8,6 +8,11 @@ int getRandomMode() {
   return fav_modes[random(0, fav_modes_num - 1)];        // получаем новый случайный номер следующего режима
 }
 
+int getRandomDuration(int iMin, int iMax, int iStep = 5000){
+  int steps = 1 + round((iMax - iMin) / iStep);
+  return iMin + iStep * random(0, steps);
+}
+
 void resetModeVariables() {
   thisdelay = 20;
   thisstep = 0;
@@ -93,6 +98,9 @@ void changeMode(int newmode) {
     thisdelay = param.delay;
     thisseg = param.segment;
     thisstep = param.step;
+    #ifdef RANDOMIZE_DURATION
+      if(randomModeOn) change_time = getRandomDuration(RANDOM_DURATION_MIN, RANDOM_DURATION_MAX, RANDOM_DURATION_STEP);
+    #endif
   }
 
   bool isSpecMode = isSpecialMode(newmode);

--- a/firmware/WS2812_FX_1.02/WS2812_FX_1.02.ino
+++ b/firmware/WS2812_FX_1.02/WS2812_FX_1.02.ino
@@ -37,6 +37,12 @@
 
 #define TRUE_RANDOM
 
+// Comment out the next line if you do not want to have random durations in random mode
+#define RANDOMIZE_DURATION
+#define RANDOM_DURATION_MIN 30000
+#define RANDOM_DURATION_MAX 90000
+#define RANDOM_DURATION_STEP 5000
+
 // Раскомментируйте следующую строку, если впараметры подключения к WiFi и MQTT серверу задаются
 // явным образом в блоке ниже. Если строка закомментирована - блок определения параметров подключения в
 // точно таком же формате вынесен в отдельный файл 'settings.h' и переменные при сборке скетча будут браться из него.

--- a/firmware/WS2812_FX_1.02/WS2812_FX_1.02.ino
+++ b/firmware/WS2812_FX_1.02/WS2812_FX_1.02.ino
@@ -35,6 +35,8 @@
 #define TOPIC_MODE_LST "led/mode/lst"   // Топик - отправка уведомления о полном списке режимов
 #define TOPIC_MODE_EDT "led/mode/edt"   // Топик - отправка параметров режима для их редактирования в Android-программе
 
+#define TRUE_RANDOM
+
 // Раскомментируйте следующую строку, если впараметры подключения к WiFi и MQTT серверу задаются
 // явным образом в блоке ниже. Если строка закомментирована - блок определения параметров подключения в
 // точно таком же формате вынесен в отдельный файл 'settings.h' и переменные при сборке скетча будут браться из него.
@@ -262,7 +264,13 @@ void setup() {
 
   Serial.println(F("\n\nWS2812_FX WiFi-MQTT v.1.02.2019.1025"));
 
-  randomSeed(analogRead(0));
+#ifdef TRUE_RANDOM
+  unsigned long seed = (int)RANDOM_REG32;
+#else
+  unsigned long seed = (int)(analogRead(0) ^ micros());
+#endif
+  NotifyInfo("seed:" + String(seed));
+  randomSeed(seed);
 
   EEPROM.begin(512);
 


### PR DESCRIPTION
Hardware randomizer will be used for initial seeding. It would be possible to use software one, but even in this case it should be slightly better as microseconds will be used in addition to reading analog input 0.